### PR TITLE
재압축 모듈을 C++20에서 빌드되도록 만듭니다

### DIFF
--- a/recompression/CMakeLists.txt
+++ b/recompression/CMakeLists.txt
@@ -10,6 +10,7 @@ OPTION(BUILD_RANGECODING "Build Range Coder/Decoder." ON)
 OPTION(BUILD_WAVEMESH "Build Wavemesh and Compression Tools." ON)
 
 SET (VTK_DIR "D:/Program Files/VTK/lib/cmake/vtk-6.3")
+add_compile_options(--std=c++20)
 SET (EXECUTABLE_OUTPUT_PATH ${PROJECT_BINARY_DIR}/bin CACHE PATH "Single output directory for building all executables.")
 SET (LIBRARY_OUTPUT_PATH ${PROJECT_BINARY_DIR}/bin CACHE PATH "Single output directory for building all libraries.")
 MARK_AS_ADVANCED(LIBRARY_OUTPUT_PATH EXECUTABLE_OUTPUT_PATH)

--- a/recompression/Common/vtkOFFWriter.cxx
+++ b/recompression/Common/vtkOFFWriter.cxx
@@ -36,8 +36,8 @@ void vtkOFFWriter::WriteData()
     }
 
 	// if input is correct , proceed.
-	register int i;
-	register double P[3];
+	int i;
+	double P[3];
 
 	vtkPolyData *polydata = this->GetInput();
 	vtkSurface *surfaceTemp = vtkSurface::New();
@@ -59,7 +59,7 @@ void vtkOFFWriter::WriteData()
 
 	vtkIdType nbPtsCell;
 	vtkIdType *ptIdList;
-	register vtkIdType j;
+	vtkIdType j;
 
 	// * write the faces *
 	for (i = 0; i <nbcls;i++)

--- a/recompression/Common/vtkSurface.cxx
+++ b/recompression/Common/vtkSurface.cxx
@@ -1587,14 +1587,14 @@ void vtkSurface::ComputeSharpVertices(double treshold)
 	double v3[3];
 	double n;
 
-	register vtkIdType i;
-	register vtkIdType s1;
-	register vtkIdType s2;
-	register vtkIdType s3;
-	register vtkIdType f1;
-	register vtkIdType f2;
-	register vtkIdType j;
-	register bool ok;
+	vtkIdType i;
+	vtkIdType s1;
+	vtkIdType s2;
+	vtkIdType s3;
+	vtkIdType f1;
+	vtkIdType f2;
+	vtkIdType j;
+	bool ok;
 
 	vtkPoints *points = this->GetPoints();
 

--- a/recompression/Common/vtkSurfaceBase.cxx
+++ b/recompression/Common/vtkSurfaceBase.cxx
@@ -392,8 +392,8 @@ void vtkSurfaceBase::ConquerOrientationFromFace(vtkIdType Face)
 double vtkSurfaceBase::GetValenceEntropy()
 {
 
-	register int i;		// Loop counter
-	register int v1;	// Valence of given point
+	int i;		// Loop counter
+	int v1;	// Valence of given point
 	double inv_number;	// 1.0 / number of points
 	double inv_Log2;	// 1.0 / log(2.0)
 	double s;			// 
@@ -436,11 +436,11 @@ double vtkSurfaceBase::GetValenceEntropy()
 
 void vtkSurfaceBase::GetValenceTab(char *filename)
 {
-	register int i;
-	register int v1;
+	int i;
+	int v1;
 
-	register int min=0;
-	register int Max=0;
+	int min=0;
+	int Max=0;
 
 	// allocate array for valences
 	vtkIntArray *Vals=vtkIntArray::New();

--- a/recompression/Compression/vtkMultiresolutionIO.cxx
+++ b/recompression/Compression/vtkMultiresolutionIO.cxx
@@ -2585,7 +2585,7 @@ void vtkMultiresolutionIO::RoiRandom(int k)
 	std::vector<int> RandomNumbers(this->Filters[0]->GetOutput()->GetNumberOfPoints());
 	for (int i = 0; i < RandomNumbers.size(); i++)
 		RandomNumbers[i] = i;
-	std::random_shuffle(RandomNumbers.begin(), RandomNumbers.end());
+	std::shuffle(RandomNumbers.begin(), RandomNumbers.end(), std::default_random_engine(std::random_device()()));
 
 	// randomly choose n/k vertices
 	for (i = 0; i < (this->Filters[0]->GetOutput()->GetNumberOfPoints())/k; i++)
@@ -2991,7 +2991,7 @@ void vtkMultiresolutionIO::RoiIncrease(int k)
 	std::vector<int> RandomNumbers(this->Filters[0]->GetOutput()->GetNumberOfPoints());
 	for (int i = 0; i < RandomNumbers.size(); i++)
 		RandomNumbers[i] = i;
-	std::random_shuffle(RandomNumbers.begin(), RandomNumbers.end());
+	std::shuffle(RandomNumbers.begin(), RandomNumbers.end(), std::default_random_engine(std::random_device()()));
 
 	if (k > this->Filters[0]->GetOutput()->GetNumberOfPoints())
 		k = this->Filters[0]->GetOutput()->GetNumberOfPoints();

--- a/recompression/README.md
+++ b/recompression/README.md
@@ -1,8 +1,11 @@
 # How to build
+
 ## Install VTK 6.3
+
 * Download VTK 6.3 and install it with CMake.  
-\
+
 ## Build this software
+
 * Insert the line below in skeleton/CMakeLists.txt
 '''
 SET (VTK_DIR "<path_dir>")


### PR DESCRIPTION
- C++20 컴파일 옵션 추가
- 최신 C++에서 지원하지 않는 `register` 키워드 사용 중단
- 최신 C++에서 지원하지 않는 `std::random_shuffle` 사용을 중단하고 `std::shuffle`로 변경
- Markdown 형식 수정
- macOS Big Sur 11.6에서 빌드되는 것 확인됨